### PR TITLE
Fix 'this' is undefined error

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,9 +1,9 @@
-import { Future } from '../';
+import { create } from '../';
 
 describe('Future', () => {
   describe('resolve', () => {
     it('should resolve the promise', done => {
-      const f = new Future<number>();
+      const f = create<number>();
       const n = 10;
       f.then(val => {
         expect(val).toBe(n);
@@ -15,7 +15,7 @@ describe('Future', () => {
 
   describe('reject', () => {
     it('should reject the promise', done => {
-      const f = new Future<number>();
+      const f = create<number>();
       const e = new Error('test error');
       f.catch(err => {
         expect(err).toBe(e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,21 @@
  * Future
  * Future extends Promise and exposes the resolve and reject methods.
  */
-export class Future<T> extends Promise<T> {
-  public resolve!: (val: T) => void;
-  public reject!: (err: Error) => void;
+export interface Future<T> extends Promise<T> {
+  resolve: (val: T) => void;
+  reject: (err: Error) => void;
+}
 
-  constructor() {
-    super((resolve, reject) => {
-      this.resolve = resolve;
-      this.reject = reject;
-    });
-  }
+/**
+ * create
+ * create creates a new Future by creating and modifying a promise instance.
+ */
+export function create<T>(): Future<T> {
+  let res: any;
+  let rej: any;
+  const promise = new Promise<T>(( _res, _rej ) => {
+    res = _res;
+    rej = _rej;
+  });
+  return Object.assign( promise, { resolve: res, reject: rej });
 }


### PR DESCRIPTION
An error gets thrown when it tries to set `this.resolve = resolve` inside the callback function passed to super call.